### PR TITLE
Update to core20 and gnome-3-38 snapcraft extension

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: five-or-more
-adopt-info: five-or-more
+version: git
 summary: Remove colored balls from the board by forming lines
 description: |
  Five or More is the GNOME port of a once-popular computer game. Align five or
@@ -11,12 +11,7 @@ description: |
  board is completely full!
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
-
-# Launchpad doesn't recognize these fields yet
-passthrough:
-  license: GPL-2.0+
-  title: Five or More
+base: core20
 
 slots:
   # for GtkApplication registration
@@ -28,9 +23,7 @@ slots:
 apps:
   five-or-more:
     command: usr/bin/five-or-more
-    extensions: [gnome-3-28]
-    plugs:
-      - gsettings
+    extensions: [ gnome-3-38 ]
     desktop: usr/share/applications/org.gnome.five-or-more.desktop
     environment:
       GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
@@ -39,12 +32,12 @@ parts:
   five-or-more:
     source: https://gitlab.gnome.org/GNOME/five-or-more.git
     source-type: git
-    source-branch: gnome-3-32
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=10)
+    #source-branch: gnome-3-32
+    #override-pull: |
+    #  snapcraftctl pull
+    #  snapcraftctl set-version $(git describe --tags --abbrev=10)
     override-build: |
-      sed -i.bak -e 's|Icon=org.gnome.five-or-more$|Icon=${SNAP}/meta/gui/org.gnome.five-or-more.png|g' data/org.gnome.five-or-more.desktop.in
+      sed -i.bak -e 's|Icon=org.gnome.five-or-more$|Icon=${SNAP}/meta/gui/org.gnome.five-or-more.png|g' $SNAPCRAFT_PART_SRC/data/org.gnome.five-or-more.desktop.in
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp ../src/data/icons/hicolor/256x256/org.gnome.five-or-more.png $SNAPCRAFT_PART_INSTALL/meta/gui/
@@ -54,12 +47,6 @@ parts:
     organize:
       snap/five-or-more/current/usr: usr
     build-packages:
-      - gettext
-      - itstool
-      - libglib2.0-dev
-      - libgnome-games-support-1-dev
-      - libgtk-3-dev
-      - librsvg2-dev
       - valac
     stage-packages:
       - libgnome-games-support-1-3


### PR DESCRIPTION
## Description

Updated the base to core20 and the extension to gnome-3-38-2004. Built and tested locally.

Note that the gnome-3-38-2004 that is currently in the stable channel (39) does not have libgnome-games-support, so five-or-more needs to be built with the one in candidate.

## Type of change

Please check only the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] General maintenance

## How Has This Been Tested?

I built this locally on my hirsute system with the following environment:
```
## From snap list
Name                 Version                     Rev    Tracking          Publisher         Notes
gnome-3-38-2004      0+git.3d25b9b               61     latest/candidate  canonical✓        -
gnome-3-38-2004-sdk  0+git.7e0e65b               87     latest/stable     canonical✓        -
snapcraft            4.8.3                       6596   latest/stable     canonical✓        classic
```
I installed the locally built snap and launched it from the desktop icon and clicked around a bit. I also launched it from the CLI and did the same, and there was only a dbus warning logged:

```
$ snap run five-or-more

(five-or-more:1301019): dbind-WARNING **: 14:41:24.171: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-ggsRSFqiQG: No such file or directory
```
But this seems harmless.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

