### PR TITLE
Remove build and stage packages, make sure to use the right libwayland

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,7 +46,5 @@ parts:
     meson-parameters: [--prefix=/snap/five-or-more/current/usr]
     organize:
       snap/five-or-more/current/usr: usr
-    build-packages:
-      - valac
-    stage-packages:
-      - libgnome-games-support-1-3
+    prime:
+      - -usr/lib/*/libwayland*


### PR DESCRIPTION
## Description

In #3 , I forgot to include these changes in my commit. This removes the build-packages and stage-packages, and makes sure that we use the correct libwayland.

## Type of change

Please check only the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] General maintenance

## How Has This Been Tested?

I built this locally on an updated hirsute system.


**Test Configuration**:

Built locally with:
* OS (please include version): Hirsute
* Snapcraft: 4.8.3 in stable

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

