### PR TITLE
Update the version string

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,7 +35,7 @@ parts:
     source-branch: gnome-3-32
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=10)
+      snapcraftctl set-version $(git describe --tags --abbrev=0)
     override-build: |
       sed -i.bak -e 's|Icon=org.gnome.five-or-more$|Icon=${SNAP}/meta/gui/org.gnome.five-or-more.png|g' $SNAPCRAFT_PART_SRC/data/org.gnome.five-or-more.desktop.in
       snapcraftctl build


### PR DESCRIPTION
## Description

Changed the version string (in the override-pull section) to use --abrev=0 instead of --abrev=10 so we can avoid having the git hash in the version string released.

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

